### PR TITLE
Add LocalizedString and LocalizedContent

### DIFF
--- a/moochub-schema.json
+++ b/moochub-schema.json
@@ -4,6 +4,93 @@
   "title": "JSON schema for MOOC providers integrated into moochub.org",
   "description": "This schema specifies the JSON format each MOOC provider must offer in order to be integrated into moochub.org",
   "type": "object",
+  "$defs": {
+    "LangString": {
+      "title": "Localized Text",
+      "description": "A localized text string with a language code",
+      "type": "object",
+      "properties": {
+        "language": {
+          "type": "string",
+          "pattern": "^[a-z]{2,3}(-[A-Z]{2})?(-[a-z0-9]{1,8})*$",
+          "description": "Language code following BCP 47 standard"
+        },
+        "string": {
+          "type": "string",
+          "description": "The actual text content",
+          "contentMediaType": "text/plain"
+        }
+      },
+      "required": [
+        "string",
+        "language"
+      ]
+    },
+    "LangContent": {
+      "title": "Localized Content",
+      "description": "A localized content string with a language code and media type",
+      "type": "object",
+      "properties": {
+        "language": true,
+        "string": true,
+        "contentMediaType": {
+          "enum": [
+            "text/plain",
+            "text/html",
+            "text/markdown"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/LangString"
+        }
+      ],
+      "required": [
+        "contentMediaType"
+      ]
+    },
+    "MultilingualString": {
+      "title": "Multilingual String",
+      "description": "A string that can be provided in multiple languages",
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "Legacy format: plain string",
+          "contentMediaType": "text/plain",
+          "deprecated": true
+        },
+        {
+          "type": "array",
+          "description": "Array of localized text entries",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/LangString"
+          }
+        }
+      ]
+    },
+    "MultilingualContent": {
+      "title": "Multilingual Content",
+      "description": "A content string that can be provided in multiple languages and different text formats",
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "Legacy format: plain string",
+          "contentMediaType": "text/plain",
+          "deprecated": true
+        },
+        {
+          "type": "array",
+          "description": "Array of localized content entries",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/LangContent"
+          }
+        }
+      ]
+    }
+  },
   "properties": {
     "links": {
       "title": "Links",
@@ -82,8 +169,8 @@
             ],
             "properties": {
               "name": {
-                "type": "string",
-                "description": "The title of the course.",
+                "$ref": "#/$defs/MultilingualString",
+                "description": "The title of the course. Can be provided as a simple string (legacy) or as a multilingual object.",
                 "example": "Confidential Communication in the Internet"
               },
               "courseCode": {
@@ -148,11 +235,15 @@
                 }
               },
               "description": {
-                "type": [
-                  "string",
-                  "null"
+                "anyOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/$defs/MultilingualContent"
+                  }
                 ],
-                "description": "Description of the course as an HTML document",
+                "description": "Description of the course. Can be provided as HTML string (legacy) or as a multilingual object with format specification.",
                 "example": "<p>A message on the Internet is sent through several networks and via different stations on its way to the target system. The individual stations are responsible for ensuring that the message is properly forwarded and finally delivered to the correct recipient. Each of these stations, if the message is sent in plain text, can receive the message and read its content. This means that a potential attacker, if he controls one of these intermediate systems, can also read the content of the message and even modify it before retransmitting it. Such attacks can have extreme effects on communication.</p>\\n\\n<p>In this course we will look at how and whether your connection to online banking is secure or whether the content of an e-mail is trustworthy. For this purpose we will deal with the basics of cryptography, security objectives and different types of encryption. In addition, we will provide insights into different models and standards that are used in practice.</p>\\n"
               },
               "inLanguage": {

--- a/moochub-schema.json
+++ b/moochub-schema.json
@@ -301,6 +301,29 @@
         "type"
       ]
     },
+    "MultilingualLabel": {
+      "type": "array",
+      "description": "List of names of an object. This array allows localized strings. A name and a language have to be given in the respective field.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "inLanguage": {
+            "type": "string",
+            "description": "The language the name is given in. Has to be a shortcode according to BCP 47.",
+            "example": "en"
+          },
+          "name": {
+            "type": "string",
+            "description": "The actual name of the object in the defined language.",
+            "example": "INTERMEDIATE"
+          }
+        },
+        "required": [
+          "inLanguage",
+          "name"
+        ]
+      }
+    },
     "EducationalLevel": {
       "title": "EducationalLevel",
       "type": "object",


### PR DESCRIPTION
# MOOChub Schema Multilingual Enhancement

## Zusammenfassung der Änderungen

Es besteht der Bedarf Kurse, die in mehreren Sprachen angeboten werden, mit mehrsprachigen Metadaten auszustatten oder nicht deutsche Metadaten als solche kennzeichnen zu können, um so Zielgruppen bei der Darstellung der Kurse besser erreichen zu können. Ich schlage vor die Kursmetadaten um Mehrsprachigkeit zu erweitern. Für Namen oder kuze Beschreibungen lässt sich hierfür der im AMB definierte Typ [Localized String](https://w3id.org/kim/amb/draft/schemas/localizedString.json) verwenden. Darauf aufbauend schlage ich einen weiteren Typ vor `LocalizedContent`, der auf `LocalizedString` aufbaut, und zuätzlich einen contentMediaTyp setzen lässt. Dieser würde es erlauben Textinhalte auch in anderen Formaten als HTML wie PlainText und Markdown zur Verfügung zu stellen, oder mindestens als solche zu kennzeichnen. Markdown eignet sich gut, da hier im Vergleich zu HTML der verarbeitenden Plattform weniger Freiheiten bei der Darstellung genommen werden können, jedoch dennoch wesentliche semantische Informationen erhalten bleiben. Die Kennzeichnung von Sprache und MediaType erlaubt außerdem eine zielgenauere und effizientere maschinelle Verarbeitung der Daten, sowie zielgerichtete automatisierte Übersetzungen. Dies würde zudem den Wert der MoochubDatenbank zum Beispiel für das KI-Modell-Training weiter stärken. Diese neuen Typen sind rückwärtskompatibel implementiert, sodass bestehende Datensätze weiterhin valide bleiben würden. Nur Moochub-Clients müssten die Änderung sofort unterstützen.

## 1. Neue Typen definiert

### [Localized String](https://w3id.org/kim/amb/draft/schemas/localizedString.json)

- Wird direkt vom AMB-Standard eingebunden
- Für kurze Texte wie Kurstitel (oder möglicherweise auch Bildbeschreibungen, Organisationsnamen, Skill-Label...)
- Fallback eingebaut, um weiterhin einfache Strings zu unterstützen
- BCP 47 konforme Sprachcodes
- Nicht existierende Sprachcodes werden als Fehler erkannt

### `LocalizedContent`  

- Für längere Inhalte wie Kursbeschreibungen
- Fallback eingebaut, um weiterhin einfache Strings zu unterstützen
- Erlaubt neben HTML auch Markdown und Plain-Text

## 2. Rückwärtskompatibilität

Das neue Schema ist rückwärtskompatibel für Provider

- Bestehende "einfache" String-Werte funktionieren weiterhin
- Neue mehrsprachige Objekte sind optional

Moochub-Clients müssten allerdings kompatibilität für die neuen Typen sicher stellen.

Alternativ könnte localizedString auch ohne Fallback eingesetzt werden, um den Umstieg zu erzwingen. Dann wäre für keine Partei eine Rückwärtskompatibilität da.

## 3. Beispiele

### Legacy Format (funktioniert weiterhin):

```json
{
    "name": "Confidential Communication",
    "description": "<p>A message on the Internet...</p>"
}
```

### Neues mehrsprachiges Format:

```json
{
    "name": {
        "de": "Vertrauliche Kommunikation",
        "en": "Confidential Communication"
    },
    "description": {
        "contentMediaType": "text/markdown",
        "content": {
            "de": "# Vertrauliche Kommunikation\n\nEine Nachricht im Internet...",
            "de": "# Confidential Communication\n\nA message on the Internet..."
        }
    }
}
```

## 5. Nächste Schritte

Für eine vollständige Implementierung könnten auch folgende Bereiche aktualisiert werden:

- oragization->name localizedString
- image->description: localizedString
- trailer->description: localizedString
- address->{country, city, street}: localizedString
- address->description: localizedString
- name und alternateName bei EducationalAlignment, EducationalLevel und Skill. sind zwar schon mehrsprachig könnte jedoch so weiter an AMB angepasst werden
