### PR TITLE
Remove ESCO and GRETA from allowed educationalFrameworks for educationalLevel.

### DIFF
--- a/moochub-schema.json
+++ b/moochub-schema.json
@@ -344,9 +344,7 @@
           "type": "string",
           "description": "The name of the educational framework that describes the educational level.",
           "enum": [
-            "ESCO",
-            "DigComp",
-            "GRETA"
+            "DigComp"
           ]
         },
         "educationalFrameworkVersion": {


### PR DESCRIPTION
Zurzeit sehen wir nur die DigComp-Level als nützliches Framework um educationalLevels von Kursen oder Kompetenzen zu beschreiben. ESCO und GRETA definieren keine Kompetenzniveaus., daher sind diese keine gültigen Angaben hier und sollten daher entfernt werden.

@MaxThomasHPI  gegebenenfalls könnten wir hier auch noch festes Vokabular für DigComp festlegen, dazu hast du ja schon Vorschläge gemacht. Gibt es noch Bemühungen diese Definition im Rahmen der Dini-AG-KIM festzusetzen, sodass auf festgesetzte Begriffe verlinkt werden könnte? Wollen wir darauf noch warten, oder den Auschluss von ESCO und GRETA schonmal als schnellen Fix durchbringen.