### PR TITLE
Add funder property

### DIFF
--- a/moochub-schema.json
+++ b/moochub-schema.json
@@ -1208,6 +1208,22 @@
                   ]
                 }
               },
+              "funder": {
+                "type": "array",
+                "uniqueItems": true,
+                "minItems": 0,
+                "description": "A person or organization that supports or supported this course through some kind of financial contribution.",
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/Organization"
+                    },
+                    {
+                      "$ref": "#/$defs/Person"
+                    }
+                  ]
+                }
+              },
               "keywords": {
                 "type": [
                   "array",


### PR DESCRIPTION
Umsetzung inspiriert von https://dini-ag-kim.github.io/amb/draft/#dfn-funder, https://schema.org/funder, https://schema.org/Course.

Im DLC stellen wir Kurse von Partnern aus, die die Kursinformationen uns mittels Moochub-Schema übermitteln. Hierbei ist es meist vom Fördermittelgeber vorgeschrieben, dass die Förderung deutlich singalisiert wird. Dies ist so über die Moochub-Daten nur als Hinweis im Beschreibungstext möglich oder per internen Absprachen durch die Verwendung bestimmer keywords. Schöner wäre eine strukturierte Angabe dieser Daten. AMB und Schema.org zeigen wie es gehen kann. Umsetzung im Moochub-Schema ist entsprechend auch unkompliziert und würde analog zu der Angabe eines "creator" oder "provider" funktionieren. In einem eigenen Feld "funder", kann dann eine Liste von Organisationen und/oder Personen genannt werden. Das Feld ist optional, kann daher von Moochub-Clients und Providern ignoriert werden und würde damit keinen großen Versionssprung erfordern.

Beispiel:
```
"funder": [
    {
        "name": "Landesregierung Schleswig-Holstein",
        "url": "https://www.schleswig-holstein.de/DE/landesregierung",
        "type": "Organization",
        "image": {
            "type": "ImageObject",
            "contentUrl": "https://lernen.dlc.sh/pluginfile.php/1/local_ildmeta/funder/1/logo_sh.svg",
            "license": [
                {
                    "identifier": "Proprietary",
                    "url": null
                }
            ]
        }
    }
]
```